### PR TITLE
chore: make R2 deployment manual

### DIFF
--- a/.github/workflows/deploy-r2.yml
+++ b/.github/workflows/deploy-r2.yml
@@ -1,9 +1,15 @@
 name: Deploy To R2
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Deployment target
+        required: true
+        type: choice
+        options:
+          - Online
+          - Staging
 
 jobs:
   deploy:
@@ -13,11 +19,20 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION || 'auto' }}
       AWS_EC2_METADATA_DISABLED: 'true'
-      R2_BUCKET: ${{ secrets.R2_BUCKET }}
       R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Select deployment settings
+        run: |
+          if [ "${{ inputs.environment }}" = "Staging" ]; then
+            echo "R2_BUCKET=${{ secrets.R2_STAGING_BUCKET }}" >> "$GITHUB_ENV"
+            echo "BUILD_COMMAND=yarn build:staging" >> "$GITHUB_ENV"
+          else
+            echo "R2_BUCKET=${{ secrets.R2_BUCKET }}" >> "$GITHUB_ENV"
+            echo "BUILD_COMMAND=yarn build" >> "$GITHUB_ENV"
+          fi
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -30,7 +45,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Build
-        run: yarn build
+        run: ${{ env.BUILD_COMMAND }}
 
       - name: Install AWS CLI
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,13 +93,13 @@ The project uses extensive path aliases configured in both vite.config.ts and ts
 
 ## CI/CD Pipeline
 
-Drone CI configuration in `.drone.yml`:
+GitHub Actions deployment configuration in `.github/workflows/deploy-r2.yml`:
 
-- Triggers on push to main branch
-- Uses Node.js 20 Docker image
-- Production build uses `npm run build` and staging can use `npm run build:staging`
-- Builds and deploys to S3 storage
-- Static asset serving from S3
+- Runs manually via `workflow_dispatch`
+- Lets the operator choose `Online` or `Staging`
+- Uses `yarn build` for `Online` and `yarn build:staging` for `Staging`
+- Uploads `dist/` to Cloudflare R2
+- Uses `R2_BUCKET` for `Online` and `R2_STAGING_BUCKET` for `Staging`
 
 ## Key Implementation Details
 

--- a/docs/github-actions-r2.md
+++ b/docs/github-actions-r2.md
@@ -1,14 +1,18 @@
 # GitHub Actions R2 Deployment
 
-`main` 分支有新的 `push` 时，会自动执行 `.github/workflows/deploy-r2.yml`：
+在 GitHub Actions 页面手动触发 `.github/workflows/deploy-r2.yml` 时，需要选择部署环境：
+
+- `Online`
+- `Staging`
 
 1. 安装依赖
-2. 执行 `yarn build`
-3. 将 `dist/` 同步到 Cloudflare R2 存储桶根目录
+2. `Online` 执行 `yarn build`，`Staging` 执行 `yarn build:staging`
+3. 将 `dist/` 同步到所选环境对应的 Cloudflare R2 存储桶根目录
 
 需要在仓库的 GitHub Secrets 中配置：
 
-- `R2_BUCKET`: 目标 R2 存储桶名称
+- `R2_BUCKET`: Online 目标 R2 存储桶名称
+- `R2_STAGING_BUCKET`: Staging 目标 R2 存储桶名称
 - `R2_ENDPOINT`: R2 S3 兼容端点，例如 `https://<account-id>.r2.cloudflarestorage.com`
 - `R2_ACCESS_KEY_ID`: R2 Access Key ID
 - `R2_SECRET_ACCESS_KEY`: R2 Secret Access Key


### PR DESCRIPTION
## Summary
- switch the R2 deploy workflow from push-on-main to workflow_dispatch
- add an Online/Staging environment selector and use R2_STAGING_BUCKET for staging
- update deployment docs to match the new manual flow

## Verification
- yarn install --frozen-lockfile
- yarn build
- yarn build:staging