### PR TITLE
Fix redirect_url after login

### DIFF
--- a/src/store/user/actions.ts
+++ b/src/store/user/actions.ts
@@ -6,6 +6,7 @@ import router from '$router/router';
 import { safeSetStorage } from '$utils/local-storage';
 import { LastPath } from '$typings/path';
 import { RouteName } from '$constants/router';
+import { getLoginRedirectQuery } from '$utils/url';
 
 export const actions: ActionTree<UserState, RootState> = {
   async getSelfInfo({ commit }) {
@@ -15,7 +16,10 @@ export const actions: ActionTree<UserState, RootState> = {
         safeSetStorage<LastPath>('last_path', {
           path: router.currentRoute.value.fullPath,
         });
-        router.push({ name: RouteName.Login });
+        router.push({
+          name: RouteName.Login,
+          query: getLoginRedirectQuery(router.currentRoute.value.query),
+        });
       } else {
         MessagePlugin.error(
           '获取登录信息失败，请刷新重试：' + selfInfo.response.msg

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,4 +1,4 @@
-import { LocationQuery } from 'vue-router';
+import { LocationQuery, LocationQueryRaw } from 'vue-router';
 import { isIP } from 'is-ip';
 import { isArray } from 'lodash-es';
 
@@ -29,4 +29,18 @@ export function processRedirectQuery(query: LocationQuery) {
     console.error("Can't parse redirect_url", e);
     return false;
   }
+}
+
+export function getLoginRedirectQuery(query: LocationQuery): LocationQueryRaw {
+  const redirectUrl = isArray(query.redirect_url)
+    ? query.redirect_url[0]
+    : query.redirect_url;
+
+  if (!redirectUrl) {
+    return {};
+  }
+
+  return {
+    redirect_url: redirectUrl,
+  };
 }

--- a/tests/redirect-query.test.ts
+++ b/tests/redirect-query.test.ts
@@ -1,0 +1,11 @@
+import assert from 'node:assert/strict';
+import { getLoginRedirectQuery } from '../src/utils/url';
+
+const redirectUrl = 'https://brando-staging.delbertbeta.life/';
+const query = getLoginRedirectQuery({
+  redirect_url: redirectUrl,
+});
+
+assert.deepEqual(query, {
+  redirect_url: redirectUrl,
+});


### PR DESCRIPTION
## Summary
- Preserve redirect_url when unauthenticated users are sent to the login page
- Reuse the preserved redirect_url after successful login
- Add a small regression test for redirect query preservation

## Test Plan
- ./node_modules/.bin/esbuild tests/redirect-query.test.ts --bundle --platform=node --format=cjs --outfile=/tmp/redirect-query-test.cjs
- node /tmp/redirect-query-test.cjs
- npm run build